### PR TITLE
Introduce violation type to add to telemetry

### DIFF
--- a/AzureFunction/ArtifactPolicyCheck.cs
+++ b/AzureFunction/ArtifactPolicyCheck.cs
@@ -80,8 +80,17 @@ namespace Microsoft.Azure.Pipelines.EvaluateArtifactPolicies
             else
             {
                 StringBuilder syncLogger = new StringBuilder();
-                var violations = Utilities.ExecutePolicyCheck(executionContext, log, imageProvenance, request.PolicyData, null, request.Variables, syncLogger, out string outputLog);
-                return new OkObjectResult(new EvaluationResponse { Violations = violations.ToList(), Logs = syncLogger.ToString() });
+                var violations = Utilities.ExecutePolicyCheck(
+                    executionContext,
+                    log,
+                    imageProvenance,
+                    request.PolicyData,
+                    null,
+                    request.Variables,
+                    syncLogger,
+                    out ViolationType violationType,
+                    out string outputLog);
+                return new OkObjectResult(new EvaluationResponse { Violations = violations.ToList(), Logs = syncLogger.ToString(), ViolationType = violationType });
             }
         }
 
@@ -107,7 +116,17 @@ namespace Microsoft.Azure.Pipelines.EvaluateArtifactPolicies
                     Utilities.LogInformation(taskStartedLog, log, taskLogger, variables, null);
 
                     string outputLog;
-                    var violations = Utilities.ExecutePolicyCheck(executionContext, log, imageProvenance, policy, taskLogger, variables, null, out outputLog);
+                    var violations = Utilities.ExecutePolicyCheck(
+                        executionContext,
+                        log,
+                        imageProvenance,
+                        policy,
+                        taskLogger,
+                        variables,
+                        null,
+                        out ViolationType violationType,
+                        out outputLog);
+
                     bool succeeded = !(violations?.Any() == true);
                     Utilities.LogInformation($"Policy check succeeded: {succeeded}", log, taskLogger, variables, null);
 

--- a/AzureFunction/Models/EvaluationResponse.cs
+++ b/AzureFunction/Models/EvaluationResponse.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Runtime.Serialization;
-using System.Text;
-
-namespace Microsoft.Azure.Pipelines.EvaluateArtifactPolicies.Models
+﻿namespace Microsoft.Azure.Pipelines.EvaluateArtifactPolicies.Models
 {
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Collections.Generic;
+    using System.Runtime.Serialization;
+
     [DataContract]
     public class EvaluationResponse
     {
@@ -14,5 +13,9 @@ namespace Microsoft.Azure.Pipelines.EvaluateArtifactPolicies.Models
 
         [DataMember(Name = "logs")]
         public string Logs { get; set; }
+
+        [DataMember(Name = "violationType")]
+        [JsonConverter(typeof(StringEnumConverter), true)]
+        public ViolationType ViolationType { get; set; }
     }
 }

--- a/AzureFunction/Models/ViolationType.cs
+++ b/AzureFunction/Models/ViolationType.cs
@@ -1,0 +1,14 @@
+﻿namespace Microsoft.Azure.Pipelines.EvaluateArtifactPolicies.Models
+{
+    using System.Runtime.Serialization;
+
+    [DataContract]
+    public enum ViolationType
+    {
+        None,
+        ViolationsListNotEmpty,
+        ViolationsNotDefined,
+        PackageNotDefined,
+        PolicyExecutionError
+    }
+}


### PR DESCRIPTION
Adding violationType to publish to telemetry.
This will give us an idea of where all the user is experiencing faliures.
The general behaviour should be to fail because of valid violations, so if the other failures are more in number, we have to help the users write proper policy regos