### PR TITLE
Fixing build breaks caused by previous commit and adding telemetry pu…

### DIFF
--- a/AzureFunction/Utilities/CustomerIntelligenceClient.cs
+++ b/AzureFunction/Utilities/CustomerIntelligenceClient.cs
@@ -1,0 +1,51 @@
+﻿namespace Microsoft.Azure.Pipelines.EvaluateArtifactPolicies.Utilities
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    using Microsoft.VisualStudio.Services.Common;
+    using Microsoft.VisualStudio.Services.CustomerIntelligence.WebApi;
+    using Microsoft.VisualStudio.Services.WebApi;
+    using Microsoft.VisualStudio.Services.WebPlatform;
+
+    public class CustomerIntelligenceClient
+    {
+        private CustomerIntelligenceClient(string url, string authToken)
+        {
+            var vssBasicCredential = new VssBasicCredential(string.Empty, authToken);
+            var vssConnection = new VssConnection(new Uri(url), vssBasicCredential);
+            this.customerIntelligenceHttpClient = vssConnection.GetClient<CustomerIntelligenceHttpClient>();
+        }
+
+        public static CustomerIntelligenceClient GetClient(string url, string authToken)
+        {
+            if (singleton == null)
+            {
+                singleton = new CustomerIntelligenceClient(url, authToken);
+            }
+
+            return singleton;
+        }
+
+        public async Task PublishArtifactPolicyEventAsync(Dictionary<string, object> properties)
+        {
+            CustomerIntelligenceEvent ciEvent = new CustomerIntelligenceEvent
+            {
+                Area = ArtifactPolicyTelemetryArea,
+                Feature = ArtifactPolicyEvaluateFeature,
+                Properties = properties
+            };
+
+            await this.customerIntelligenceHttpClient.PublishEventsAsync(new CustomerIntelligenceEvent[] { ciEvent });
+
+        }
+
+        private CustomerIntelligenceHttpClient customerIntelligenceHttpClient;
+
+        private static CustomerIntelligenceClient singleton;
+        private const string ArtifactPolicyTelemetryArea = "ArtifactPolicy";
+        private const string ArtifactPolicyEvaluateFeature = "ArtifactPolicyEvaluate";
+    }
+}

--- a/AzureFunction/Utilities/TaskClient.cs
+++ b/AzureFunction/Utilities/TaskClient.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.Azure.Pipelines.EvaluateArtifactPolicies
+﻿namespace Microsoft.Azure.Pipelines.EvaluateArtifactPolicies.Utilities
 {
     using System;
     using System.Collections.Generic;

--- a/AzureFunction/Utilities/TaskLogger.cs
+++ b/AzureFunction/Utilities/TaskLogger.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.Azure.Pipelines.EvaluateArtifactPolicies
+﻿namespace Microsoft.Azure.Pipelines.EvaluateArtifactPolicies.Utilities
 {
     using System;
     using System.Collections.Generic;

--- a/Tests/Microsoft.Azure.Pipelines.EvaluateArtifactPolicies.Test.csproj
+++ b/Tests/Microsoft.Azure.Pipelines.EvaluateArtifactPolicies.Test.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Mocks\MockLogger.cs" />
-    <Compile Include="UtilitiesTests.cs" />
+    <Compile Include="CommonUtilitiesTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AzureFunction\Microsoft.Azure.Pipelines.EvaluateArtifactPolicies.csproj">


### PR DESCRIPTION
…blishing for async flow

There were some compilation errors introduced with the last commit, as I had not modified the test files, with a changed signature

Also added telemetry publishing code for async flow. Using CustomerIntelligenceHttpClient to publish the result of the policy after updating the check